### PR TITLE
Disable page numbers per default

### DIFF
--- a/gistt.cls
+++ b/gistt.cls
@@ -108,7 +108,7 @@
 \newcommand{\EI}{\end{itemize}}
 \raggedbottom
 
-%\pagestyle{empty}
+\pagestyle{empty}
 %\thispagestyle{empty}
 \let\ps@plain\ps@empty
 


### PR DESCRIPTION
GI Softwaretechnik-Trends requires papers to be submitted without page numbers, so I suggest to disable them per default.